### PR TITLE
Add support for priority filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ The following configuration settings are supported:
 * `log_group`: (Required) The name of the cloudwatch log group to write logs into. This log group must
   be created before running the program.
 
+* `log_priority`: (Optional) The highest priority of the log messages to read (on a 0-7 scale). This defaults
+    to DEBUG (all messages). This has a behaviour similar to `journalctl -p <priority>`. At the moment, only
+    a single value can be specified, not a range. Possible values are: `0,1,2,3,4,5,6,7` or one of the corresponding
+    `"emerg", "alert", "crit", "err", "warning", "notice", "info", "debug"`.
+    When a single log level is specified, all messages with this log level or a lower (hence more important)
+    log level are read and pushed to CloudWatch. For more information about priority levels, look at
+    https://www.freedesktop.org/software/systemd/man/journalctl.html
+
 * `log_stream`: (Optional) The name of the cloudwatch log stream to write logs into. This defaults to
   the EC2 instance id. Each running instance of this application (along with any other applications
   writing logs into the same log group) must have a unique `log_stream` value. If the given log stream

--- a/journal.go
+++ b/journal.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"github.com/coreos/go-systemd/sdjournal"
+	"strconv"
+)
+
+func AddLogFilters(journal *sdjournal.Journal, config *Config) {
+
+	// Add Priority Filters
+	if config.LogPriority < DEBUG {
+		for p, _ := range PriorityJSON {
+			if p <= config.LogPriority {
+				journal.AddMatch("PRIORITY=" + strconv.Itoa(int(p)))
+			}
+		}
+		journal.AddDisjunction()
+	}
+}

--- a/main.go
+++ b/main.go
@@ -50,6 +50,8 @@ func run(configFilename string) error {
 	}
 	defer journal.Close()
 
+	AddLogFilters(journal, config)
+
 	state, err := OpenState(config.StateFilename)
 	if err != nil {
 		return fmt.Errorf("Failed to open %s: %s", config.StateFilename, err)


### PR DESCRIPTION
In our environment we sometimes run things with DEBUG mode.
In these cases journald is filled with a bunch of messages, irrelevant
for the normal work mode, but reading them and pushing to CloudWatch
uses considerable amount of io/cpu on the host system.
- Add a configuration parameter "log_priority" to filter log messages
  similar to the "journalctl -p <prio>" command.

Signed-off-by: Alex Lourie djay.il@gmail.com
Signed-off-by: Alex Lourie alex@instaclustr.com
