### PR TITLE
Add ability to load arbitrary journal directories via config

### DIFF
--- a/config.go
+++ b/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	LogStreamName  string
 	LogPriority    Priority
 	StateFilename  string
+	JournalDir     string
 	BufferSize     int
 }
 
@@ -31,6 +32,7 @@ type fileConfig struct {
 	LogStreamName string `hcl:"log_stream"`
 	LogPriority   string `hcl:"log_priority"`
 	StateFilename string `hcl:"state_file"`
+	JournalDir    string `hcl:"journal_dir"`
 	BufferSize    int    `hcl:"buffer_size"`
 }
 
@@ -119,6 +121,7 @@ func LoadConfig(filename string) (*Config, error) {
 	}
 
 	config.StateFilename = fConfig.StateFilename
+	config.JournalDir = fConfig.JournalDir
 
 	if fConfig.BufferSize != 0 {
 		config.BufferSize = fConfig.BufferSize

--- a/config.go
+++ b/config.go
@@ -38,19 +38,19 @@ func getLogLevel(priority string) (Priority, error) {
 
 	logLevels := map[Priority][]string{
 		EMERGENCY: {"0", "emerg"},
-		ALERT: {"1", "alert"},
-		CRITICAL: {"2", "crit"},
-		ERROR: {"3", "err"},
-		WARNING: {"4", "warning"},
-		NOTICE: {"5", "notice"},
-		INFO: {"6", "info"},
-		DEBUG: {"7", "debug"},
+		ALERT:     {"1", "alert"},
+		CRITICAL:  {"2", "crit"},
+		ERROR:     {"3", "err"},
+		WARNING:   {"4", "warning"},
+		NOTICE:    {"5", "notice"},
+		INFO:      {"6", "info"},
+		DEBUG:     {"7", "debug"},
 	}
 
 	for i, s := range logLevels {
-	    if s[0] == priority || s[1] == priority {
-	        return i, nil
-	    }
+		if s[0] == priority || s[1] == priority {
+			return i, nil
+		}
 	}
 
 	return DEBUG, fmt.Errorf("'%s' is unsupported log priority", priority)

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/coreos/go-systemd/sdjournal"
@@ -44,7 +45,14 @@ func run(configFilename string) error {
 		return fmt.Errorf("error reading config: %s", err)
 	}
 
-	journal, err := sdjournal.NewJournal()
+	var journal *sdjournal.Journal
+	if config.JournalDir == "" {
+		journal, err = sdjournal.NewJournal()
+	} else {
+		log.Printf("using journal dir: %s", config.JournalDir)
+		journal, err = sdjournal.NewJournalFromDir(config.JournalDir)
+	}
+
 	if err != nil {
 		return fmt.Errorf("error opening journal: %s", err)
 	}

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -75,4 +75,3 @@ func unmarshalRecord(journal *sdjournal.Journal, toVal reflect.Value) error {
 
 	return nil
 }
-

--- a/writer.go
+++ b/writer.go
@@ -44,7 +44,7 @@ func (w *Writer) WriteBatch(records []Record) (string, error) {
 		})
 	}
 
-	putEvents := func () error {
+	putEvents := func() error {
 		request := &cloudwatchlogs.PutLogEventsInput{
 			LogEvents:     events,
 			LogGroupName:  &w.logGroupName,
@@ -61,7 +61,7 @@ func (w *Writer) WriteBatch(records []Record) (string, error) {
 		return nil
 	}
 
-	createStream := func () error {
+	createStream := func() error {
 		request := &cloudwatchlogs.CreateLogStreamInput{
 			LogGroupName:  &w.logGroupName,
 			LogStreamName: &w.logStreamName,


### PR DESCRIPTION
Allows for an extra optional param `journal_dir` in the configuration to allow for the use of an arbitrary directory for the binary to find journals. 

Handy for cases like aggregation via `journal-remote` where it makes sense to maintain a separate journal directory.
