### PR TITLE
Fix #1 by passing around copies of records instead of pointers

### DIFF
--- a/config.go
+++ b/config.go
@@ -96,7 +96,7 @@ func LoadConfig(filename string) (*Config, error) {
 	} else {
 		instanceId, err := metaClient.GetMetadata("instance-id")
 		if err != nil {
-			return nil, fmt.Errorf("unable to detect EC2 instance id", err)
+			return nil, fmt.Errorf("unable to detect EC2 instance id: %s", err)
 		}
 		config.EC2InstanceId = instanceId
 	}

--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func run(configFilename string) error {
 
 	bufSize := config.BufferSize
 
-	records := make(chan *Record)
+	records := make(chan Record)
 	batches := make(chan []Record)
 
 	go ReadRecords(config.EC2InstanceId, journal, records, skip)


### PR DESCRIPTION
Testing with a loop of "logger $i"; I noticed that about every second message vanished and every other message was duplicated. Taking a look at the code, the *Record channel seems to be the reason for this - at high message rates, the Record data is overwritten with the new data before it is serialized to JSON for delivery to Cloudwatch.

This PR fixes this by changing the *Record channel to a Record channel. After this change, we did not observe any dropped or duplicated events anymore.
