### PR TITLE
Decode json messages and embed them

### DIFF
--- a/record.go
+++ b/record.go
@@ -39,7 +39,7 @@ type Record struct {
 	Hostname    string       `json:"hostname,omitempty" journald:"_HOSTNAME"`
 	Transport   string       `json:"transport,omitempty" journald:"_TRANSPORT"`
 	Priority    Priority     `json:"priority" journald:"PRIORITY"`
-	Message     string       `json:"message" journald:"MESSAGE"`
+	Message     interface{}  `json:"message" journald:"MESSAGE"`
 	MessageId   string       `json:"messageId,omitempty" journald:"MESSAGE_ID"`
 	Errno       int          `json:"machineId,omitempty" journald:"ERRNO"`
 	Syslog      RecordSyslog `json:"syslog,omitempty"`

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -66,6 +67,19 @@ func unmarshalRecord(journal *sdjournal.Journal, toVal reflect.Value) error {
 			break
 		case reflect.String:
 			fieldVal.SetString(value)
+			break
+		// Only Message should be an interface{}
+		case reflect.Interface:
+			// See if we can unmarshal an arbitrary json object
+			if value != "" && value[0] == '{' {
+				var objectVal map[string]interface{}
+				if json.Unmarshal([]byte(value), &objectVal) == nil {
+				  fieldVal.Set(reflect.ValueOf(objectVal))
+					continue
+				}
+			}
+			// Otherwise it's a string
+			fieldVal.Set(reflect.ValueOf(value))
 			break
 		default:
 			// Should never happen


### PR DESCRIPTION
Love the project. We're trying it out at the moment. Wanted a cleaner way to blat logs at CloudWatch Logs with more context and minimal footprint — this is perfect.

I'm spitting out nginx access logs using a json format like so:

![image](https://cloud.githubusercontent.com/assets/14028/18576310/be4bef1a-7c23-11e6-8bb3-4964ca739023.png)

I'd like for these to be recognized as a JSON, parsed into an object, and have the object embedded as the "message" instead of just as string. That way I can [do json filtering](http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html#d0e4022) and use [jmes queries](https://github.com/jorgebastida/awslogs/pull/88) to do cool things(tm).

<img width="582" alt="screenshot 2016-09-16 16 09 12" src="https://cloud.githubusercontent.com/assets/14028/18576774/ed58851c-7c27-11e6-8b2a-cd4c89eb2f8d.png">

This is even more neat if you combine it with something like [lograge](https://github.com/roidrage/lograge) with json output for deeply-queryable and aggregatable logs!
