### PR TITLE
vendor: Add missing coreos/pkg/dlopen

### DIFF
--- a/vendor/github.com/coreos/pkg/dlopen/dlopen.go
+++ b/vendor/github.com/coreos/pkg/dlopen/dlopen.go
@@ -1,0 +1,82 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dlopen provides some convenience functions to dlopen a library and
+// get its symbols.
+package dlopen
+
+// #cgo LDFLAGS: -ldl
+// #include <stdlib.h>
+// #include <dlfcn.h>
+import "C"
+import (
+	"errors"
+	"fmt"
+	"unsafe"
+)
+
+var ErrSoNotFound = errors.New("unable to open a handle to the library")
+
+// LibHandle represents an open handle to a library (.so)
+type LibHandle struct {
+	Handle  unsafe.Pointer
+	Libname string
+}
+
+// GetHandle tries to get a handle to a library (.so), attempting to access it
+// by the names specified in libs and returning the first that is successfully
+// opened. Callers are responsible for closing the handler. If no library can
+// be successfully opened, an error is returned.
+func GetHandle(libs []string) (*LibHandle, error) {
+	for _, name := range libs {
+		libname := C.CString(name)
+		defer C.free(unsafe.Pointer(libname))
+		handle := C.dlopen(libname, C.RTLD_LAZY)
+		if handle != nil {
+			h := &LibHandle{
+				Handle:  handle,
+				Libname: name,
+			}
+			return h, nil
+		}
+	}
+	return nil, ErrSoNotFound
+}
+
+// GetSymbolPointer takes a symbol name and returns a pointer to the symbol.
+func (l *LibHandle) GetSymbolPointer(symbol string) (unsafe.Pointer, error) {
+	sym := C.CString(symbol)
+	defer C.free(unsafe.Pointer(sym))
+
+	C.dlerror()
+	p := C.dlsym(l.Handle, sym)
+	e := C.dlerror()
+	if e != nil {
+		return nil, fmt.Errorf("error resolving symbol %q: %v", symbol, errors.New(C.GoString(e)))
+	}
+
+	return p, nil
+}
+
+// Close closes a LibHandle.
+func (l *LibHandle) Close() error {
+	C.dlerror()
+	C.dlclose(l.Handle)
+	e := C.dlerror()
+	if e != nil {
+		return fmt.Errorf("error closing %v: %v", l.Libname, errors.New(C.GoString(e)))
+	}
+
+	return nil
+}

--- a/vendor/github.com/coreos/pkg/dlopen/dlopen_example.go
+++ b/vendor/github.com/coreos/pkg/dlopen/dlopen_example.go
@@ -1,0 +1,56 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// +build linux
+
+package dlopen
+
+// #include <string.h>
+// #include <stdlib.h>
+//
+// int
+// my_strlen(void *f, const char *s)
+// {
+//   size_t (*strlen)(const char *);
+//
+//   strlen = (size_t (*)(const char *))f;
+//   return strlen(s);
+// }
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+func strlen(libs []string, s string) (int, error) {
+	h, err := GetHandle(libs)
+	if err != nil {
+		return -1, fmt.Errorf(`couldn't get a handle to the library: %v`, err)
+	}
+	defer h.Close()
+
+	f := "strlen"
+	cs := C.CString(s)
+	defer C.free(unsafe.Pointer(cs))
+
+	strlen, err := h.GetSymbolPointer(f)
+	if err != nil {
+		return -1, fmt.Errorf(`couldn't get symbol %q: %v`, f, err)
+	}
+
+	len := C.my_strlen(strlen, cs)
+
+	return int(len), nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -160,7 +160,6 @@
 		},
 		{
 			"checksumSHA1": "O8c/VKtW34XPJNNlyeb/im8vWSI=",
-			"origin": "github.com/coreos/go-systemd/vendor/github.com/coreos/pkg/dlopen",
 			"path": "github.com/coreos/pkg/dlopen",
 			"revision": "3ac0863d7acf3bc44daf49afef8919af12f704ef",
 			"revisionTime": "2016-07-27T23:37:14Z"


### PR DESCRIPTION
Apparently this package is missing in the vendor folder even though it is in `vendor.json`.

``` sh
$ docker run --rm -v "$PWD":/usr/local/go/src/github.com/saymedia/journald-cloudwatch-logs -w /usr/local/go/src/github.com/saymedia/journald-cloudwatch-logs golang:1.7.1 sh -c 'apt-get update && apt-get -y install libsystemd-dev && go build -v'
```

```
Get:1 http://security.debian.org jessie/updates InRelease [63.1 kB]
Get:2 http://security.debian.org jessie/updates/main amd64 Packages [401 kB]
Ign http://httpredir.debian.org jessie InRelease
Get:3 http://httpredir.debian.org jessie-updates InRelease [145 kB]
Get:4 http://httpredir.debian.org jessie-updates/main amd64 Packages [17.6 kB]
Get:5 http://httpredir.debian.org jessie Release.gpg [2373 B]
Get:6 http://httpredir.debian.org jessie Release [148 kB]
Get:7 http://httpredir.debian.org jessie/main amd64 Packages [9064 kB]
Fetched 9842 kB in 23s (420 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  libsystemd-dev
0 upgraded, 1 newly installed, 0 to remove and 4 not upgraded.
Need to get 94.6 kB of archives.
After this operation, 190 kB of additional disk space will be used.
Get:1 http://httpredir.debian.org/debian/ jessie/main libsystemd-dev amd64 215-17+deb8u5 [94.6 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 94.6 kB in 10s (8921 B/s)
Selecting previously unselected package libsystemd-dev:amd64.
(Reading database ... 14767 files and directories currently installed.)
Preparing to unpack .../libsystemd-dev_215-17+deb8u5_amd64.deb ...
Unpacking libsystemd-dev:amd64 (215-17+deb8u5) ...
Setting up libsystemd-dev:amd64 (215-17+deb8u5) ...
vendor/github.com/coreos/go-systemd/sdjournal/functions.go:19:2: cannot find package "github.com/coreos/pkg/dlopen" in any of:
    /usr/local/go/src/github.com/saymedia/journald-cloudwatch-logs/vendor/github.com/coreos/pkg/dlopen (vendor tree)
    /usr/local/go/src/vendor/github.com/coreos/pkg/dlopen
    /usr/local/go/src/github.com/coreos/pkg/dlopen (from $GOROOT)
    /go/src/github.com/coreos/pkg/dlopen (from $GOPATH)
```

So I did this:

``` sh
govendor remove github.com/coreos/pkg/dlopen
govendor add github.com/coreos/pkg/dlopen
```

(via govendor v1.0.8)
