### PR TITLE
Error out on AccessDeniedException

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -84,12 +84,11 @@ func (w *Writer) WriteBatch(records []Record) (string, error) {
 
 				err = putEvents()
 				if err != nil {
-					return "", err
+					return "", fmt.Errorf("failed to put events: %s", err)
 				}
 			}
-		} else {
-			return "", err
 		}
+		return "", fmt.Errorf("failed to put events: %s", err)
 	}
 
 	return w.nextSequenceToken, nil


### PR DESCRIPTION
If the user forgets to setup IAM permissions properly the agent then hangs and never exits which makes systemd think that it's running.

```sh
$ systemctl status journald-cloudwatch-logs.service
● journald-cloudwatch-logs.service - Journald log forwarder to CW Logs
   Loaded: loaded (/run/systemd/system/journald-cloudwatch-logs.service; static; vendor preset: disabled)
   Active: active (running) since Mon 2016-11-07 11:23:12 UTC; 3h 56min ago
     Docs: https://github.com/saymedia/journald-cloudwatch-logs
 Main PID: 1114 (journald-cloudw)
    Tasks: 8
   Memory: 13.8M
      CPU: 1.508s
   CGroup: /system.slice/journald-cloudwatch-logs.service
           └─1114 /opt/bin/journald-cloudwatch-logs /etc/journald-cloudwatch-logs.hcl
```

I believe the agent should just exit early and exit with error exit code.

### After bugfix
```sh
$ systemctl status journald-cloudwatch-logs.service
● journald-cloudwatch-logs.service - Journald log forwarder to CW Logs
   Loaded: loaded (/run/systemd/system/journald-cloudwatch-logs.service; static; vendor preset: disabled)
   Active: activating (auto-restart) (Result: exit-code) since Mon 2016-11-07 15:19:35 UTC; 3s ago
     Docs: https://github.com/saymedia/journald-cloudwatch-logs
  Process: 15831 ExecStart=/opt/bin/journald-cloudwatch-logs /etc/journald-cloudwatch-logs.hcl (code=exited, status=2)
 Main PID: 15831 (code=exited, status=2)
```
```
# /opt/bin/journald-cloudwatch-logs /etc/journald-cloudwatch-logs.hcl
Failed to write to cloudwatch: failed to put events: AccessDeniedException: User: arn:aws:sts::123456789012:assumed-role/test-hubot-instance-role/i-9ba33312 is not authorized to perform: logs:PutLogEvents on resource: arn:aws:logs:us-east-1:123456789012:log-group:test-hubot/host:log-stream:i-9ba33312
	status code: 400, request id: fa44143a-a4fd-12e6-bc88-9f75d5be232b
```

I first thought it would be best to just bail out on any AWS error, but then I don't know if there are any plans on implementing retry logic for `Throttling` error and/or whether there are generally any plans on reworking the error handling there.