### PR TITLE
Add EC2 metadata and OS environment variable expansion support in the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,22 @@ The following configuration settings are supported:
   new events will be written to CloudWatch Logs every second even if the buffer does not fill, but
   this setting provides a maximum batch size to use when clearing a large backlog of events, e.g.
   from system boot when the program starts for the first time.
+
+Additionally values in the configuration file can contain variable expansions of the form ${name} or $name
+which will be expanded from either the AWS Instance Identity Document or the operating system environment
+variables.  At the time of writing the supported InstanceIdentityDocument variables are:
+
+* `${AvailabilityZone}`: The name of the availability zone the instance is running, eg `ap-southeast-2b`
+* `${PrivateIP}`: The AWS internal private IP address of the instance, eg `172.1.2.3`
+* `${Version}`: The version of the InstanceIdentityDocument definition?, eg `2010-08-31`
+* `${Region}`: The name of the region the instance is running in, eg `ap-southeast-2`
+* `${InstanceID}`: The instance identifier, eg `i-0123456789abcdef0`
+* `${InstanceType}`: The type of the instance, eg `x1.32xlarge`
+* `${AccountID}`: The amazon web services account the instance is running under, eg `098765432123`
+* `${ImageID}`: The AMI (image) id the instance was launched from, eg `ami-a1b2c3d4`
+* `${KernelID}`: The kernel ID used to launch the instance (PV instances only)
+* `${RamdiskID}`: The ramdisk ID used to launch the instance (PV instances only)
+* `${Architecture}`: The CPU architecture of the instance, eg `x86_64`
   
 ### AWS API access
 

--- a/README.md
+++ b/README.md
@@ -98,21 +98,24 @@ The following configuration settings are supported:
   this setting provides a maximum batch size to use when clearing a large backlog of events, e.g.
   from system boot when the program starts for the first time.
 
-Additionally values in the configuration file can contain variable expansions of the form ${name} or $name
-which will be expanded from either the AWS Instance Identity Document or the operating system environment
-variables.  At the time of writing the supported InstanceIdentityDocument variables are:
+Additionally values in the configuration file can contain variable expansions of the form
+${instance.<key>} which will be exapnded from the AWS Instance Identity Document or ${env.<name>}
+which will be expanded from the operating system environment variables, if a key does not exist
+it expands to the empty string.
 
-* `${AvailabilityZone}`: The name of the availability zone the instance is running, eg `ap-southeast-2b`
-* `${PrivateIP}`: The AWS internal private IP address of the instance, eg `172.1.2.3`
-* `${Version}`: The version of the InstanceIdentityDocument definition?, eg `2010-08-31`
-* `${Region}`: The name of the region the instance is running in, eg `ap-southeast-2`
-* `${InstanceID}`: The instance identifier, eg `i-0123456789abcdef0`
-* `${InstanceType}`: The type of the instance, eg `x1.32xlarge`
-* `${AccountID}`: The amazon web services account the instance is running under, eg `098765432123`
-* `${ImageID}`: The AMI (image) id the instance was launched from, eg `ami-a1b2c3d4`
-* `${KernelID}`: The kernel ID used to launch the instance (PV instances only)
-* `${RamdiskID}`: The ramdisk ID used to launch the instance (PV instances only)
-* `${Architecture}`: The CPU architecture of the instance, eg `x86_64`
+At the time of writing, in early 2017, the supported InstanceIdentityDocument variables are:
+
+* `${instance.AvailabilityZone}`: The name of the availability zone the instance is running, eg `ap-southeast-2b`
+* `${instance.PrivateIP}`: The AWS internal private IP address of the instance, eg `172.1.2.3`
+* `${instance.Version}`: The version of the InstanceIdentityDocument definition?, eg `2010-08-31`
+* `${instance.Region}`: The name of the region the instance is running in, eg `ap-southeast-2`
+* `${instance.InstanceID}`: The instance identifier, eg `i-0123456789abcdef0`
+* `${instance.InstanceType}`: The type of the instance, eg `x1.32xlarge`
+* `${instance.AccountID}`: The amazon web services account the instance is running under, eg `098765432123`
+* `${instance.ImageID}`: The AMI (image) id the instance was launched from, eg `ami-a1b2c3d4`
+* `${instance.KernelID}`: The kernel ID used to launch the instance (PV instances only)
+* `${instance.RamdiskID}`: The ramdisk ID used to launch the instance (PV instances only)
+* `${instance.Architecture}`: The CPU architecture of the instance, eg `x86_64`
   
 ### AWS API access
 

--- a/config.go
+++ b/config.go
@@ -184,7 +184,6 @@ func expandFileConfig(config *fileConfig, metaClient *ec2metadata.EC2Metadata) {
 	rconfig := reflect.ValueOf(config)
 	for i := 0; i < rconfig.Elem().NumField(); i++ {
 		field := rconfig.Elem().Field(i)
-		ftype := rconfig.Elem().Type().Field(i)
 		if field.Type() != reflect.TypeOf("") {
 			continue
 		}


### PR DESCRIPTION
This branch adds support for variable expansion in the config file, in particular I had a need to name the log stream with general category information, but still include unique instance information (in this case the id) as part of the name on auto-scaling instances. With this patch that can now be done directly in the config using eg:
`log_stream = "UAT-WEB-${InstanceID}"`