### PR TITLE
Improve timestamp precision

### DIFF
--- a/record.go
+++ b/record.go
@@ -26,7 +26,7 @@ var PriorityJSON = map[Priority][]byte{
 
 type Record struct {
 	InstanceId     string       `json:"instanceId,omitempty"`
-	TimeUsec       int64        `json:"-"`
+	TimeNsec       int64        `json:"-"`
 	PID            int          `json:"pid" journald:"_PID"`
 	UID            int          `json:"uid" journald:"_UID"`
 	GID            int          `json:"gid" journald:"_GID"`

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -14,7 +14,7 @@ func UnmarshalRecord(journal *sdjournal.Journal, to *Record) error {
 	if err == nil {
 		// FIXME: Should use the realtime from the log record,
 		// but for some reason journal.GetRealtimeUsec always fails.
-		to.TimeUsec = time.Now().Unix() * 1000
+		to.TimeNsec = time.Now().UnixNano()
 	}
 	return err
 }

--- a/writer.go
+++ b/writer.go
@@ -40,7 +40,7 @@ func (w *Writer) WriteBatch(records []Record) (string, error) {
 
 		events = append(events, &cloudwatchlogs.InputLogEvent{
 			Message:   aws.String(jsonData),
-			Timestamp: aws.Int64(int64(record.TimeUsec)),
+			Timestamp: aws.Int64(record.TimeNsec / 1e6),
 		})
 	}
 


### PR DESCRIPTION
Cloudwatch allows millisecond precision, and since we have access to nanosecond precision time we might as well use it here.